### PR TITLE
Adapt to toml-rb gem 1.0.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,4 +16,4 @@ supports 'ubuntu'
 
 depends 'systemd'
 
-gem 'toml', '~> 0.1.2'
+gem 'toml', '~> 1.0.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,4 +16,4 @@ supports 'ubuntu'
 
 depends 'systemd'
 
-gem 'toml', '~> 1.0.0'
+gem 'toml-rb', '~> 1.0.0'

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -15,6 +15,6 @@ end
 action :create do
   require 'toml-rb'
   converge_if_changed do
-    ::IO.write(path, ::TomlRB::Generator.new(config).body)
+    ::IO.write(path, ::TomlRB.dump(config))
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -4,17 +4,17 @@ property :config, Hash, required: true
 default_action :create
 
 load_current_value do
-  require 'toml'
+  require 'toml-rb'
   if ::File.exist?(path)
-    config ::TOML.load_file(path)
+    config ::TomlRB.load_file(path)
   else
     current_value_does_not_exist!
   end
 end
 
 action :create do
-  require 'toml'
+  require 'toml-rb'
   converge_if_changed do
-    ::IO.write(path, ::TOML::Generator.new(config).body)
+    ::IO.write(path, ::TomlRB::Generator.new(config).body)
   end
 end


### PR DESCRIPTION
toml-rb gem has been released with a breaking change on its namespace

Change-Id: Ie3246f2c6c462b935dd68080c3428263e22cbb55